### PR TITLE
BL-659 update api to reflect correct schema used in the backend

### DIFF
--- a/documentation/openapi.yaml
+++ b/documentation/openapi.yaml
@@ -59,13 +59,38 @@ paths:
               schema:
                 type: object
                 items:
-                  "$ref": "#/components/schemas/Case"
+                  "$ref": "#/components/schemas/pageResponse"
         "400":
-          description: No cases found for given parameters
+          description: ErrorDTO
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  "$ref": "#/components/schemas/ErrorDTO"
+        "404":
+          description: ErrorDTO
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  "$ref": "#/components/schemas/ErrorDTO"
+
 
 components:
   schemas:
-    Case:
+    pageResponse:
+      type: object
+      properties:
+        totalPages:
+          type: integer
+        page:
+          type: array
+        items:
+          "$ref": "#/components/schemas/case"
+
+    case:
       type: object
       properties:
         asylumOffice:
@@ -78,4 +103,10 @@ components:
           type: string
         dateReceived:
           type: string
+
+    ErrorDTO:
+      type: object
+        properties:
+          message:
+            type: string
   

--- a/documentation/openapi.yaml
+++ b/documentation/openapi.yaml
@@ -23,7 +23,7 @@ paths:
             type: string   # Presents as a "0"-delimited list ( e.g. /cases?citizenship=ANGOLA0BELGIUM0FRANCE ) to be extracted to an array
         - name: outcome
           in: query
-          description: Case Outcome   # A selection of case outcomes by which to filter
+          description: Case Outcome   # A selection of case outcomes by which to filter -- 'Deny/Referral', 'Grant', or 'Admin Close/Dismissal'
           required: false
           schema:
             type: string

--- a/documentation/openapi.yaml
+++ b/documentation/openapi.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.3
+info:
+  title: HRF Asylum Case API
+  description:  HRF Asylum Case docs
+  version: 1.0.0
+
+paths:
+  /cases:
+    get:
+      summary: Gets case data   # Filtering is optional based on query string parameters
+      parameters:
+        - name: office
+          in: query
+          description: Asylum Office # The list of asylum offices by which to filter
+          required: false
+          schema:
+            type: string   # Presents as a comma-delimited list ( e.g. /cases?asylumOffice=zny,zmi,zsf ) to be extracted to an array
+        - name: citizenship
+          in: query
+          description: Citizenship   # The list of citizenships by which to filter
+          required: false
+          schema:
+            type: string   # Presents as a "0"-delimited list ( e.g. /cases?citizenship=ANGOLA0BELGIUM0FRANCE ) to be extracted to an array
+        - name: outcome
+          in: query
+          description: Case Outcome   # A selection of case outcomes by which to filter
+          required: false
+          schema:
+            type: string
+        - name: from
+          in: query
+          description: Start date for the Completion search criteria   # A starting date from which to filter cases -- refers to completionDate in the database
+          required: false
+          schema:
+            type: string
+        - name: to
+          in: query
+          description: End date for the Completion search criteria   # An ending date to which to filter cases -- refers to completionDate in the database
+          required: false
+          schema:
+            type: string
+        - name: received
+          in: query
+          description: Date Received  # The date at which information regarding this particular case was entered into the database
+          required: false
+          schema:
+            type: string
+        - name: fiscal
+          in: query
+          description: Fiscal Year   # A boolean specifying whether years should be specified as fiscal/calendar
+          required: false
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  "$ref": "#/components/schemas/Case"
+        "400":
+          description: No cases found for given parameters
+
+components:
+  schemas:
+    Case:
+      type: object
+      properties:
+        asylumOffice:
+          type: string
+        citizenship:
+          type: string
+        caseOutcome:
+          type: string
+        completion:
+          type: string
+        currentDate:
+          type: string
+  

--- a/documentation/openapi.yaml
+++ b/documentation/openapi.yaml
@@ -74,8 +74,8 @@ components:
           type: string
         caseOutcome:
           type: string
-        completion:
+        completionDate:
           type: string
-        currentDate:
+        dateReceived:
           type: string
   


### PR DESCRIPTION
## Description

Updated existing openapi.yaml file with changes decided by the team. The decision was to shorten query parameter names from camel case to one word. [Slack Link](https://bloomtech-learners.slack.com/archives/C03HULR962H/p1659110250532009) This file was moved from [asylum-rg-docs](https://github.com/BloomTech-Labs/asylum-rg-docs/tree/main/API_Documentation) to the backend repo.
``` java 
Database:
asylumOffice - (The US Asylum Office district in which the case was heard)
citizenship - (The petitioners nation of origin, per their birth record)
caseOutcome - (One of three values representing the ultimate disposition of the case)
completionDate - (The date the case was decided)
dateRecieved - (The date the case was entered into the database)
```
``` java
Query Parameters:
office - (The list of asylum offices by which to filter)
citizenship - (The list of citizenships by which to filter)
outcome - (A selection of case outcomes by which to filter)
from - (A starting date (inclusive) from which to filter cases -- refers to completionDate in the database)
to - (An ending date (inclusive) to which to filter cases -- refers to completionDate in the database)
fiscal - (A boolean specifying whether years should be specified as fiscal/calendar)
```

#### Video Link

[Loom Video](https://www.loom.com/share/ce3d77c599c74a7c9e0711409a9a87be)

#### Jira Link


<blockquote class="jira-card"><a href="https://bloomtechlabs.atlassian.net/jira/software/c/projects/BL/boards/8?modal=detail&selectedIssue=BL-659">BL-659 Update API to Reflect Correct Schema</a></blockquote>

## Checklist:

- [X] My design/diagram follows the style guidelines of this project
- [X] My docs are organized within an appropriate folder structure in our repo
- [X] Pull request description clearly describes docs made & motivations for said additions